### PR TITLE
Scythe print: handle reduced motion in animation container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 - `SearchResults` & `ResultsList` components
-- update 
+- update `AnimationContainer` to handle reduced motion
 
 ## [0.2.0]
 - `lib/animation-container.js`: `AnimationContainer` component, `slideUp` and `slideDown` animations

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 - `SearchResults` & `ResultsList` components
+- update 
 
 ## [0.2.0]
 - `lib/animation-container.js`: `AnimationContainer` component, `slideUp` and `slideDown` animations

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -17,15 +17,23 @@ export const slideDown = keyframes`
     opacity: 0;
   }
 `;
+export const fadeOut = keyframes`
+  to {
+    opacity: 0;
+  }
+`;
 
 const AnimationWrap = styled.div`
-  animation-name: ${({ animation }) => animation};
+  animation-name: ${({ animation, reducedMotionAnimation }) => animation || reducedMotionAnimation};
+  @media (prefers-reduced-motion: reduce) {
+    animation-name: ${({ reducedMotionAnimation }) => reducedMotionAnimation};
+  }
   animation-duration: var(--animation-duration, 0.1s);
   animation-timing-function: ease-out;
   animation-fill-mode: forwards;
 `;
 
-export const AnimationContainer = ({ animation, duration, children, onAnimationEnd, ...props }) => {
+export const AnimationContainer = ({ animation, reducedMotionAnimation, duration, children, onAnimationEnd, ...props }) => {
   const [active, setActive] = React.useState(false);
   const ref = React.useRef();
 
@@ -37,6 +45,7 @@ export const AnimationContainer = ({ animation, duration, children, onAnimationE
     <AnimationWrap
       data-module="AnimationContainer"
       animation={active ? animation : null}
+      reducedMotionAnimation={active ? reducedMotionAnimation : null}
       style={{
         '--duration': duration,
       }}
@@ -50,7 +59,8 @@ export const AnimationContainer = ({ animation, duration, children, onAnimationE
 };
 
 AnimationContainer.propTypes = {
-  animation: PropTypes.any.isRequired,
+  animation: PropTypes.any,
+  reducedMotionAnimation: PropTypes.any,
   children: PropTypes.func.isRequired,
   onAnimationEnd: PropTypes.func.isRequired,
 };
@@ -97,12 +107,15 @@ export const StoryAnimationContainer = () => {
         `}
       </CodeExample>
       <PropsDefinition>
-        <Prop name="animation" required>
+        <Prop name="animation">
           The CSS animation to run. Can either be the name of an animation declared in a stylesheet or an object returned from{' '}
           <a href="https://www.styled-components.com/docs/api#keyframes">
             styled-components' <code>keyframes</code> helper
           </a>
           .
+        </Prop>
+        <Prop name="reducedMotionAnimation">
+          The animation to run if the user has "prefers-reduced-motion" set. If no value for the 
         </Prop>
         <Prop name="duration">The duration of the animation. Defaults to "0.1s".</Prop>
         <Prop name="children" required>

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -118,6 +118,8 @@ export const StoryAnimationContainer = () => {
         </Prop>
         <Prop name="reducedMotionAnimation">
           The animation to run if the user has "prefers-reduced-motion" set, or if no value is provided for the "animation" prop.
+          Read the <a href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions">WCAG guidelines</a>{' '}
+          for more information on accessibility in animations.
         </Prop>
         <Prop name="duration">The duration of the animation. Defaults to "0.1s".</Prop>
         <Prop name="children" required>

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -5,7 +5,7 @@ import styled, { keyframes } from 'styled-components';
 import { Button } from './button';
 import { code, CodeExample, PropsDefinition, Prop } from './story-utils';
 
-const nullAnimation = keyframes``
+const nullAnimation = keyframes``;
 
 export const slideUp = keyframes`
   to {
@@ -24,7 +24,6 @@ export const fadeOut = keyframes`
     opacity: 0;
   }
 `;
-
 
 const AnimationWrap = styled.div`
   animation-name: ${({ animation, reducedMotionAnimation }) => animation};

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -115,7 +115,7 @@ export const StoryAnimationContainer = () => {
           .
         </Prop>
         <Prop name="reducedMotionAnimation">
-          The animation to run if the user has "prefers-reduced-motion" set. If no value for the 
+          The animation to run if the user has "prefers-reduced-motion" set, or if no value is provided for the "animation" prop.
         </Prop>
         <Prop name="duration">The duration of the animation. Defaults to "0.1s".</Prop>
         <Prop name="children" required>

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -104,7 +104,7 @@ export const StoryAnimationContainer = () => {
       <p>The AnimationContainer component renders a container that adds animations to callbacks.</p>
       <CodeExample>
         {code`
-          <AnimationContainer animation={slideUp} reducedMotionAnimation={fadeOut} onAnimationEnd={() => featureProject(project)}>
+          <AnimationContainer animation={slideUp} onAnimationEnd={() => featureProject(project)}>
             {(startAnimation) => <Project project={project} onFeature={startAnimation} />}
           </AnimationContainer>
         `}
@@ -130,9 +130,10 @@ export const StoryAnimationContainer = () => {
       </PropsDefinition>
       <ExampleBlock>
         <h3>Pinned Projects</h3>
+        <p>(if "reduce motion" is active, these will dissapear without animating out.)</p>
         <Grid>
           {pinnedProjects.map((project) => (
-            <AnimationContainer key={project.id} onAnimationEnd={() => unpinProject(project)}>
+            <AnimationContainer key={project.id} animation={slideDown} onAnimationEnd={() => unpinProject(project)}>
               {(animateAndUnpin) => (
                 <ProjectItem>
                   <h3>{project.domain}</h3>
@@ -145,9 +146,10 @@ export const StoryAnimationContainer = () => {
           ))}
         </Grid>
         <h3>Recent Projects</h3>
+        <p>(if "reduce motion" is active, these will fade out.)</p>
         <Grid>
           {recentProjects.map((project) => (
-            <AnimationContainer key={project.id} onAnimationEnd={() => pinProject(project)}>
+            <AnimationContainer key={project.id} animation={slideUp} reducedMotionAnimation={fadeOut} onAnimationEnd={() => pinProject(project)}>
               {(animateAndPin) => (
                 <ProjectItem>
                   <h3>{project.domain}</h3>

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -26,7 +26,7 @@ export const fadeOut = keyframes`
 `;
 
 const AnimationWrap = styled.div`
-  animation-name: ${({ animation, reducedMotionAnimation }) => animation};
+  animation-name: ${({ animation }) => animation};
   @media (prefers-reduced-motion: reduce) {
     animation-name: ${({ reducedMotionAnimation }) => reducedMotionAnimation};
   }

--- a/lib/animation-container.js
+++ b/lib/animation-container.js
@@ -5,6 +5,8 @@ import styled, { keyframes } from 'styled-components';
 import { Button } from './button';
 import { code, CodeExample, PropsDefinition, Prop } from './story-utils';
 
+const nullAnimation = keyframes``
+
 export const slideUp = keyframes`
   to {
     transform: translateY(-50px);
@@ -23,8 +25,9 @@ export const fadeOut = keyframes`
   }
 `;
 
+
 const AnimationWrap = styled.div`
-  animation-name: ${({ animation, reducedMotionAnimation }) => animation || reducedMotionAnimation};
+  animation-name: ${({ animation, reducedMotionAnimation }) => animation};
   @media (prefers-reduced-motion: reduce) {
     animation-name: ${({ reducedMotionAnimation }) => reducedMotionAnimation};
   }
@@ -44,8 +47,8 @@ export const AnimationContainer = ({ animation, reducedMotionAnimation, duration
   return (
     <AnimationWrap
       data-module="AnimationContainer"
-      animation={active ? animation : null}
-      reducedMotionAnimation={active ? reducedMotionAnimation : null}
+      animation={active ? animation || reducedMotionAnimation || nullAnimation : null}
+      reducedMotionAnimation={active ? reducedMotionAnimation || nullAnimation : null}
       style={{
         '--duration': duration,
       }}
@@ -101,7 +104,7 @@ export const StoryAnimationContainer = () => {
       <p>The AnimationContainer component renders a container that adds animations to callbacks.</p>
       <CodeExample>
         {code`
-          <AnimationContainer animation={slideUp} onAnimationEnd={() => featureProject(project)}>
+          <AnimationContainer animation={slideUp} reducedMotionAnimation={fadeOut} onAnimationEnd={() => featureProject(project)}>
             {(startAnimation) => <Project project={project} onFeature={startAnimation} />}
           </AnimationContainer>
         `}
@@ -122,14 +125,14 @@ export const StoryAnimationContainer = () => {
           A render prop, which passes in a callback function that starts the animation.
         </Prop>
         <Prop name="onAnimationEnd" required>
-          A callback function, called when the animation is completed.
+          A callback function, called when the animation is completed. If no animation is provided, this runs immediately.
         </Prop>
       </PropsDefinition>
       <ExampleBlock>
         <h3>Pinned Projects</h3>
         <Grid>
           {pinnedProjects.map((project) => (
-            <AnimationContainer key={project.id} animation={slideDown} onAnimationEnd={() => unpinProject(project)}>
+            <AnimationContainer key={project.id} onAnimationEnd={() => unpinProject(project)}>
               {(animateAndUnpin) => (
                 <ProjectItem>
                   <h3>{project.domain}</h3>
@@ -144,7 +147,7 @@ export const StoryAnimationContainer = () => {
         <h3>Recent Projects</h3>
         <Grid>
           {recentProjects.map((project) => (
-            <AnimationContainer key={project.id} animation={slideUp} onAnimationEnd={() => pinProject(project)}>
+            <AnimationContainer key={project.id} onAnimationEnd={() => pinProject(project)}>
               {(animateAndPin) => (
                 <ProjectItem>
                   <h3>{project.domain}</h3>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-<<<<<<< HEAD
   "version": "0.2.0",
-=======
-  "version": "0.1.1",
->>>>>>> d666282f5b8d1f91576a9c3a9bbe366f710b3979
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
http://scythe-print.glitch.me/#StoryAnimationContainer

- add `reducedMotionAnimation` prop to AnimationContainer for alternate animations if prefers-reduced-motion is enabled

@clottman I'd like the docs to include a link to guidelines on what kind of animations are suitable for reduced motion uses, do you have suggestions?