### PR TITLE
Shrouded march: remove icon size docs

### DIFF
--- a/lib/icon.js
+++ b/lib/icon.js
@@ -225,7 +225,6 @@ Icon.propTypes = {
 };
 Icon.defaultProps = {
   alt: '',
-  size: 'inline',
 };
 
 export const StoryIcon = () => (
@@ -249,18 +248,6 @@ const GiantIcon = styled(Icon)`
 
 export const StoryIcon_sizes = () => (
   <>
-    <p>Icon sizes are configurable with the "size" property, which correspond to the theme's font sizes.</p>
-    <Icon icon="pushpin" size="tiny" />
-    &nbsp;
-    <Icon icon="pushpin" size="small" />
-    &nbsp;
-    <Icon icon="pushpin" size="normal" />
-    &nbsp;
-    <Icon icon="pushpin" size="big" />
-    &nbsp;
-    <Icon icon="pushpin" size="bigger" />
-    &nbsp;
-    <Icon icon="pushpin" size="huge" />
     <p>By default, Icons match the size of their surrounding text.</p>
     <h1 style={{ fontSize: '2rem' }}>
       Pinned Projects <Icon icon="pushpin" />


### PR DESCRIPTION
Icon sizes are always inline, unless directly overridden