### PR TITLE
Change button whitespace to normal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.2] - 2019-08-30
+### Changed
+- `lib/button.js`: changed `white-space` property so buttons don't overflow their containers
+
 ## [0.5.1] - 2019-08-30
 ### Changed
 - `lib/button.js`: added `:disabled` styling for buttons

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2019-08-30
+### Changed
+- `lib/button.js`: added `:disabled` styling for buttons
+
 ## [0.5.0] - 2019-08-19
 ### Added
 - `lib/live-announcer.js`: aria-live announcer components for Notification a11y

--- a/lib/button.js
+++ b/lib/button.js
@@ -36,6 +36,12 @@ const StyledButton = styled.span`
   font-weight: 600;
   line-height: 1;
   position: relative;
+  &:disabled,
+  button:disabled &,
+  a:disabled & {
+    opacity: 0.5;
+    pointer-events: none;
+  }
   // Most buttons will have capital letters, but many will not have descenders.
   // As a result, even padding on buttons frequently looks unbalanced,
   // so we apply extra padding to the top to correct this.

--- a/lib/button.js
+++ b/lib/button.js
@@ -60,6 +60,7 @@ const hover = (...args) => css`
   button:hover &,
   a:hover & {
     ${css(...args)}
+    text-decoration: none;
   }
   &:active,
   button:active &,

--- a/lib/button.js
+++ b/lib/button.js
@@ -48,7 +48,7 @@ const StyledButton = styled.span`
   // Note that this is font-specific and proportional to font size,
   // and at smaller sizes this is complicated by pixel rounding.
   padding: 0.375em 0.5em 0.1875em;
-  white-space: nowrap;
+  white-space: normal;
   text-decoration: none;
 
   ${({ variant }) => variants[variant]}

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -235,7 +235,7 @@ export const StoryPopover = () => (
           </Info>
           <DangerZone>
             <Button size="small" variant="warning" onClick={() => console.log('boom')}>
-              Delete Team
+              Delete Team let's make this button really ridiculously long, ok
             </Button>
           </DangerZone>
         </WidePopover>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -235,7 +235,7 @@ export const StoryPopover = () => (
           </Info>
           <DangerZone>
             <Button size="small" variant="warning" onClick={() => console.log('boom')}>
-              Delete Team let's make this button really ridiculously long, ok
+              Delete Team
             </Button>
           </DangerZone>
         </WidePopover>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
I think this is what we want even for popovers: 
![Screen Shot 2019-08-30 at 4 30 01 PM](https://user-images.githubusercontent.com/3011231/64049644-7bb1ad80-cb43-11e9-804e-7516ceb90663.png)
`white-space: normal`

![Screen Shot 2019-08-30 at 4 30 23 PM](https://user-images.githubusercontent.com/3011231/64049648-7f453480-cb43-11e9-840e-f5ae1372e689.png)
`white-space: nowrap`
