### PR TITLE
Updated active button background colors

### DIFF
--- a/lib/themes.js
+++ b/lib/themes.js
@@ -72,5 +72,9 @@ export const darkTheme = {
     border: '#B8B8B8',
     secondaryBackground: '#636363',
     background: '#222',
+    selected: {
+      text: '#fff',
+      background: '#244776',
+    },
   },
 };

--- a/lib/themes.js
+++ b/lib/themes.js
@@ -56,8 +56,8 @@ export const lightTheme = {
       background: '#47F68D',
     },
     selected: {
-      text: '#fff',
-      background: '#244776',
+      text: '#222',
+      background: '#d9e5f1',
     },
   },
 };


### PR DESCRIPTION
Used of lighter active button background color for lightTheme to prevent high contrast switching when clicking buttons.

active button color for lightTheme:
![active-btn](https://user-images.githubusercontent.com/519336/64280666-9ad38500-cf1f-11e9-9d91-5cdddf8bfc46.gif)

active button color for darkTheme:
![dark-theme](https://user-images.githubusercontent.com/519336/64280725-b9398080-cf1f-11e9-851b-94f2fdf2559e.gif)


Preview changes at https://mulberry-tuck.glitch.me/