### PR TITLE
Gorgeous persimmon - Added nav

### DIFF
--- a/lib/button.js
+++ b/lib/button.js
@@ -129,7 +129,7 @@ const Container = styled.div`
   }
 `;
 
-export const StoryUnstyledButton = () => (
+export const StoryButton_unstyled = () => (
   <>
     <p>
       The UnstyledButton component renders buttons that have the behaviors of <code>{`<button>`}</code> elements, but with all the styling removed.

--- a/lib/stories.js
+++ b/lib/stories.js
@@ -64,13 +64,45 @@ const Select = ({ value, options, onChange }) => (
   </select>
 );
 
-const Main = styled.main`
-  margin: 0 auto;
-  padding: var(--space-2);
+
+const Wrapper = styled.div`
+  display: flex;
   max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const Nav = styled.div`
+  position: sticky;
+  top: 10.5rem;
+  height: calc(100% - 10.5rem);
+  flex: 0 0 15%;
+  border-right: 1px solid var(--colors-border);  
+  @media (max-width: 1200px){
+    display: none;
+  }
+`;
+
+const NavLink = styled.a`
+  margin: 0.5em 0;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const Main = styled.main`
+  flex: 0 0 85%;
+  padding: var(--space-2);
+  max-width: 900px;
   code {
     font-family: var(--fonts-mono);
     font-size: 1em;
+  }
+  @media (max-width: 1200px){
+    max-width: 1200px;
+    flex: inherit;
   }
 `;
 
@@ -87,10 +119,12 @@ const Section = styled.section`
 `;
 
 const SectionH = styled.h2`
-  color: var(--colors-secondary);
+  color: var(--colors-primary);
   padding: 0 0 var(--space-1);
   margin: 0 auto var(--space-2);
 `;
+
+console.log(modules);
 
 const themeOptions = Object.entries(themes).map(([name, theme]) => ({ id: name, label: name }));
 
@@ -98,19 +132,34 @@ const AppContainer = () => {
   const [themeID, setThemeID] = React.useState(themeOptions[0].id);
 
   return (
-    <Main>
-      <RootStyle theme={themes[themeID]} />
-      <header>
-        <h1>Glitch Shared Components</h1>
-        <p>This is a library of React components used on Glitch's community site and editor.</p>
-        <Select value={themeID} onChange={(id) => setThemeID(id)} options={themeOptions} />
-        <h2>Basic setup</h2>
-        <p>
-          These components are designed to work with multiple themes. In order to use these components, you will need to inject a theme using the{' '}
-          <a href="#Story_RootStyle_and_LocalStyle">RootStyle or LocalStyle</a> components.
-        </p>
-        <CodeExample>
-          {code`
+    <>
+    <Wrapper>
+      <Nav>
+        {modules.map((module, i) => (
+          Object.entries(module).map(
+            ([name], i) => 
+              (name.startsWith('Story') && !name.includes('_')) && (
+                <NavLink href={`#${name}`}>
+                  {name.replace(/_/g, ' ').replace('Story', '')}
+                </NavLink>
+              )
+            ) 
+          ),
+        )}
+      </Nav>
+      <Main>
+        <RootStyle theme={themes[themeID]} />
+        <header>
+          <h1>Glitch Shared Components</h1>
+          <p>This is a library of React components used on Glitch's community site and editor.</p>
+          <Select value={themeID} onChange={(id) => setThemeID(id)} options={themeOptions} />
+          <h2>Basic setup</h2>
+          <p>
+            These components are designed to work with multiple themes. In order to use these components, you will need to inject a theme using the{' '}
+            <a href="#Story_RootStyle_and_LocalStyle">RootStyle or LocalStyle</a> components.
+          </p>
+          <CodeExample>
+            {code`
             import React from 'react'
             import ReactDOM from 'react-dom'
             import { RootStyle, lightTheme, Button } from '@fogcreek/shared-components'
@@ -123,25 +172,27 @@ const AppContainer = () => {
               document.getElementById('root')
             )
           `}
-        </CodeExample>
-      </header>
+          </CodeExample>
+        </header>
 
-      {modules.map((module, i) => (
-        <div key={i}>
-          {Object.entries(module).map(
-            ([name, Component]) =>
-              name.startsWith('Story') && (
-                <Section id={name} key={name}>
-                  <SectionLink href={`#${name}`}>
-                    <SectionH>{name.replace(/_/g, ' ').replace('Story', '')}</SectionH>
-                  </SectionLink>
-                  <Component />
-                </Section>
-              ),
-          )}
-        </div>
-      ))}
-    </Main>
+        {modules.map((module, i) => (
+          <div key={i}>
+            {Object.entries(module).map(
+              ([name, Component]) =>
+                name.startsWith('Story') && (
+                  <Section id={name} key={name}>
+                    <SectionLink href={`#${name}`}>
+                      <SectionH>{name.replace(/_/g, ' ').replace('Story', '')}</SectionH>
+                    </SectionLink>
+                    <Component />
+                  </Section>
+                ),
+            )}
+          </div>
+        ))}
+      </Main>
+    </Wrapper>
+    </>
   );
 };
 

--- a/lib/stories.js
+++ b/lib/stories.js
@@ -124,8 +124,6 @@ const SectionH = styled.h2`
   margin: 0 auto var(--space-2);
 `;
 
-console.log(modules);
-
 const themeOptions = Object.entries(themes).map(([name, theme]) => ({ id: name, label: name }));
 
 const AppContainer = () => {

--- a/lib/story-utils.js
+++ b/lib/story-utils.js
@@ -6,6 +6,7 @@ export const CodeExample = styled.pre`
   font-size: var(--fontSizes-big);
   background-color: var(--colors-secondaryBackground);
   padding: var(--space-2);
+  white-space: pre-wrap;
 `;
 
 // trim indentation for multiline strings


### PR DESCRIPTION
I created navigation to make it easier to go through the Shared Components documentation.

I tried to only include the primary components (for example, `Avatar` appears in the nav, but not `Avatar sizes` or `Avatar variants`). 

The nav hides for smaller screens (<1200px)

![shared-component-nav](https://user-images.githubusercontent.com/519336/66322162-aedc1f00-e8ef-11e9-985f-17b2b4d3fa66.gif)

Testable at https://gorgeous-persimmon.glitch.me
