### PR TITLE
Blossom bougon: add startOpen prop to popover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.0] - 2019-10-17
+### Changed
+- `lib/block.js`: added styles that were being overridden on glitch.com
+- `lib/popover.js`: added "startOpen" prop for popovers that should be open on page load
+
 ## [0.12.0] - 2019-10-16
 ### Changed
 - `lib/icon.js`: added "blockArrowDown" and "blockArrowUp" icons

--- a/lib/block.js
+++ b/lib/block.js
@@ -8,7 +8,7 @@ import { CodeExample, PropsDefinition, Prop } from './story-utils';
 const TitleWrap = styled.header`
   display: flex;
   align-items: baseline;
-  font-size: var(--fontSizes-big);
+  font-size: var(--fontSizes-small);
   padding: var(--space-1);
   background-color: var(--colors-secondaryBackground);
 `;
@@ -16,7 +16,7 @@ const TitleContent = styled.h2`
   flex: 1 0 auto;
   margin: 0;
   padding: 0 var(--space-1);
-  font-size: var(--fontSizes-big);
+  font-size: var(--fontSizes-small);
 `;
 
 export const Title = ({ children, onBack, onBackRef, onClose, onCloseRef, ...props }) => (
@@ -44,6 +44,7 @@ const variants = {
 
 const Section = styled.section`
   padding: var(--space-1);
+  margin: 0;
   ${({ variant }) => variants[variant]};
   border-top: 1px solid var(--colors-border);
   &:first-child {

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -110,6 +110,8 @@ const useClickOutside = (open, onClickOutside) => {
   return ref;
 };
 
+const openOnLaod 
+
 const useStack = (defaultState) => {
   const [stack, setStack] = React.useState([defaultState]);
   const top = stack[stack.length - 1];
@@ -152,7 +154,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" startOpen={onOpen()} ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen={open} ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>
@@ -169,6 +171,7 @@ Popover.propTypes = {
   initialView: PropTypes.string,
   children: PropTypes.func.isRequired,
   contentProps: PropTypes.object,
+  startOpen: PropTypes.bool,
 };
 
 const WidePopover = styled.div`

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -119,7 +119,7 @@ const useStack = (defaultState) => {
   return { top, push, pop, clear };
 };
 
-export const Popover = ({ align, renderLabel, views = {}, initialView, children, contentProps, ...props }) => {
+export const Popover = ({ align, renderLabel, views = {}, initialView,  children, contentProps, ...props }) => {
   const [open, setOpen] = React.useState(false);
   const focusedOnMount = React.useRef();
   const toggleRef = React.useRef();

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -119,7 +119,7 @@ const useStack = (defaultState) => {
   return { top, push, pop, clear };
 };
 
-export const Popover = ({ align, renderLabel, views = {}, initialView, children, contentProps, ...props }) => {
+export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen, children, contentProps, ...props }) => {
   const [open, setOpen] = React.useState(false);
   const focusedOnMount = React.useRef();
   const toggleRef = React.useRef();
@@ -139,7 +139,6 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, children,
   }, [open, activeView]);
 
   const rootRef = useClickOutside(open, onClose);
-  const openOnLoad = () => {setOpen(true);}
 
   const onToggle = (e) => {
     if (open) {
@@ -153,7 +152,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, children,
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen={onOpen()} ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>
@@ -223,7 +222,7 @@ export const StoryPopover = () => (
       <Prop name="toggleProps">Additional props passed to the popover toggle button.</Prop>
       <Prop name="contentProps">Additional props passed to the popover content wrapper.</Prop>
     </PropsDefinition>
-    <Popover align="left" renderLabel={(labelProps) => <Button {...labelProps}>Delete Team</Button>}>
+    <Popover align="left" startOpen renderLabel={(labelProps) => <Button {...labelProps}>Delete Team</Button>}>
       {({ onClose, focusedOnMount }) => (
         <WidePopover>
           <Title onCloseRef={focusedOnMount} onClose={onClose}>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -119,7 +119,7 @@ const useStack = (defaultState) => {
   return { top, push, pop, clear };
 };
 
-export const Popover = ({ align, renderLabel, views = {}, initialView,  children, contentProps, ...props }) => {
+export const Popover = ({ align, renderLabel, views = {}, initialView, children, contentProps, ...props }) => {
   const [open, setOpen] = React.useState(false);
   const focusedOnMount = React.useRef();
   const toggleRef = React.useRef();
@@ -139,6 +139,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView,  children
   }, [open, activeView]);
 
   const rootRef = useClickOutside(open, onClose);
+  const openOnLoad = () => {setOpen(true);}
 
   const onToggle = (e) => {
     if (open) {

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -110,8 +110,6 @@ const useClickOutside = (open, onClickOutside) => {
   return ref;
 };
 
-const openOnLaod 
-
 const useStack = (defaultState) => {
   const [stack, setStack] = React.useState([defaultState]);
   const top = stack[stack.length - 1];
@@ -154,7 +152,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" startOpen={open} ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen={() => {setOpen(true)}} ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -153,7 +153,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" startOpen={setOpen(true)} ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen={onOpen()} ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -121,7 +121,7 @@ const useStack = (defaultState) => {
 };
 
 export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen, children, contentProps, ...props }) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(startOpen);
   const focusedOnMount = React.useRef();
   const toggleRef = React.useRef();
   const { top: activeView, push: setActiveView, pop: onBack, clear } = useStack(initialView);
@@ -153,7 +153,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" startOpen={onOpen()} ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -70,10 +70,11 @@ const PopoverInner = styled.div`
   background-color: var(--colors-background);
   font-size: var(--fontSizes-small);
   border-radius: var(--rounded);
+  text-align: left;
 
   border: 1px solid var(--colors-border);
   box-shadow: var(--popShadow);
-  z-index: 1;
+  z-index: 10;
 `;
 
 const PopoverContent = ({ align, children, ...props }) => {
@@ -152,7 +153,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (
-    <PopoverContainer data-module="Popover" startOpen={() => {setOpen(true)}} ref={rootRef} {...props}>
+    <PopoverContainer data-module="Popover" startOpen={setOpen(true)} ref={rootRef} {...props}>
       {renderLabel({ onClick: onToggle, ref: toggleRef })}
       {open && (
         <PopoverContent align={align} {...contentProps}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.122.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
Some popovers in the community site need the ability to be open on page load, so this adds that functionality