### PR TITLE
Popover fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.2] - 2019-11-04
+### Changed
+- `lib/popover.js`: fix issue with popovers stealing back focus
+
 ## [0.13.1] - 2019-10-31
 ### Changed
 - `lib/text-input.js`: fixed CSS error breaking font size

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -133,7 +133,6 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
   const onClose = () => {
     setOpen(false);
     clear();
-    toggleRef.current.focus();
   };
   React.useEffect(() => {
     if (open && focusedOnMount.current) focusedOnMount.current.focus();

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -188,7 +188,7 @@ export const StoryPopover = () => (
       {code`
         <Popover
           align="right"
-          renderLabel={({ onClick }) => <MenuButton onClick={onClick} />}
+          renderLabel={({ onClick, ref }) => <MenuButton onClick={onClick} ref={ref} />}
         >
           {({ onClose }) => (
             <MenuOptions onClose={onClose} />

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -123,7 +123,7 @@ const useStack = (defaultState) => {
 export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen, children, contentProps, ...props }) => {
   const [open, setOpen] = React.useState(startOpen);
   const focusedOnMount = React.useRef();
-  const toggleRef = React.useRef(); // not actively used anymore, but keeping for backwards compatibility
+  const toggleRef = React.useRef();
   const { top: activeView, push: setActiveView, pop: onBack, clear } = useStack(initialView);
   const activeViewFunc = views[activeView] || children;
   const onOpen = () => {
@@ -147,6 +147,7 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
       onOpen();
     }
   };
+  // if a user has tabbed inside a popover and presses escape they should return back to the popover button
   const returnFocusOnClose = () => {
     onClose()
     toggleRef.current.focus();
@@ -205,7 +206,7 @@ export const StoryPopover = () => (
           <dt>onClick</dt>
           <dd>A callback function to toggle the popover.</dd>
           <dt>ref</dt>
-          <dd>(deprecated) A ref for the toggle button, so that it is focused when the popover closes.</dd>
+          <dd>A ref for the toggle button, so that it is focused when the popover closes.</dd>
         </dl>
       </Prop>
       <Prop name="views">An object mapping the names of secondary popover pages to functions that render them.</Prop>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -123,7 +123,7 @@ const useStack = (defaultState) => {
 export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen, children, contentProps, ...props }) => {
   const [open, setOpen] = React.useState(startOpen);
   const focusedOnMount = React.useRef();
-  const toggleRef = React.useRef();
+  const toggleRef = React.useRef(); // not actively used anymore, but keeping for backwards compatibility
   const { top: activeView, push: setActiveView, pop: onBack, clear } = useStack(initialView);
   const activeViewFunc = views[activeView] || children;
   const onOpen = () => {
@@ -183,7 +183,7 @@ export const StoryPopover = () => (
       {code`
         <Popover
           align="right"
-          renderLabel={({ onClick, ref }) => <MenuButton onClick={onClick} ref={ref} />}
+          renderLabel={({ onClick }) => <MenuButton onClick={onClick} />}
         >
           {({ onClose }) => (
             <MenuOptions onClose={onClose} />
@@ -201,7 +201,7 @@ export const StoryPopover = () => (
           <dt>onClick</dt>
           <dd>A callback function to toggle the popover.</dd>
           <dt>ref</dt>
-          <dd>A ref for the toggle button, so that it is focused when the popover closes.</dd>
+          <dd>(deprecated) A ref for the toggle button, so that it is focused when the popover closes.</dd>
         </dl>
       </Prop>
       <Prop name="views">An object mapping the names of secondary popover pages to functions that render them.</Prop>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -147,8 +147,12 @@ export const Popover = ({ align, renderLabel, views = {}, initialView, startOpen
       onOpen();
     }
   };
+  const returnFocusOnClose = () => {
+    onClose()
+    toggleRef.current.focus();
+  }
 
-  useEscape(open, onClose);
+  useEscape(open, returnFocusOnClose);
 
   // see https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fogcreek/shared-components",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
Currently when you open a popover and click anywhere else, your focus returns back to the popover button that opened it. This was done purposely to ensure users do not lose focus when they press escape. But it looks like we've accidentally created other focus bugs by accident. Now if you click to open a popover and then click on any other interactive element your focus does not go to that interactive element but back to the old popover to show you closed it. This means if you're clicking around between popovers or between input fields it's pretty easy to get confused. Here's a screen recording illustrating what I'm talking about: https://recordit.co/0e7KhdW4Mf

My first thought was to remove this functionality entirely, but I realized when you tab _into_ a popover and then press escape you lose your focused element. So now I'm suggesting that in general we don't steal back focus _except_ if you use escape to close in which case grab back focus to the button that opens the popover. 

To play around with this you can use:
https://fluff-hollyhock.glitch.me/#StoryPopover

or you can use
https://glass-mercury.glitch.me/
which should have the changed Popover component running, it might be helpful to see the git diff here:
https://github.com/FogCreek/Glitch-Community/pull/1046/files
I tried to mock out all the Popovers in that remix, but I probably missed a few, irl we won't need to change the community code at all. 

Shoutout to Cassey (and Greg!) for pairing on this!