### PR TITLE
Rich-red: make navigation usable when dev tools is open, and add links to popover/overlay blocks

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -68,7 +68,7 @@ const Container = styled.div`
   width: 400px;
 `;
 
-export const StoryBlocks_for_Overlay_and_Popover_content = () => (
+export const Story_Blocks_for_Overlay_and_Popover_content = () => (
   <>
     <p>The Title component is used for rendering headers in Overlay and Popover components.</p>
     <CodeExample>{`<Title onBack={onBack}>Your Projects</Title>`}</CodeExample>

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -124,7 +124,7 @@ export const StoryOverlay = () => {
 
   return (
     <>
-      <p>The Overlay component renders an accessible modal.</p>
+      <p>The Overlay component renders an accessible modal. See <a href="#Story_Blocks_for_Overlay_and_Popover_content">blocks to use with Overlays</a>.</p>
       <CodeExample>
         {code`
           <Overlay open={open} onClose={onClose}>

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -183,7 +183,7 @@ const WidePopover = styled.div`
 
 export const StoryPopover = () => (
   <>
-    <p>The Popover component renders accessible and nestable popovers. See <a her</p>
+    <p>The Popover component renders accessible and nestable popovers. See <a href="#Story_Blocks_for_Overlay_and_Popover_content">blocks to use with Popovers</a>.</p>
     <CodeExample>
       {code`
         <Popover

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -183,7 +183,7 @@ const WidePopover = styled.div`
 
 export const StoryPopover = () => (
   <>
-    <p>The Popover component renders accessible and nestable popovers.</p>
+    <p>The Popover component renders accessible and nestable popovers. See <a her</p>
     <CodeExample>
       {code`
         <Popover

--- a/lib/stories.js
+++ b/lib/stories.js
@@ -73,8 +73,9 @@ const Wrapper = styled.div`
 
 const Nav = styled.div`
   position: sticky;
-  top: 10.5rem;
-  height: calc(100% - 10.5rem);
+  top: 1em;
+  height: calc(100vh - 1em);
+  overflow: scroll;
   flex: 0 0 15%;
   border-right: 1px solid var(--colors-border);  
   @media (max-width: 1200px){

--- a/lib/stories.js
+++ b/lib/stories.js
@@ -73,9 +73,9 @@ const Wrapper = styled.div`
 
 const Nav = styled.div`
   position: sticky;
-  top: 1em;
-  height: calc(100vh - 1em);
-  overflow: scroll;
+  top: 5em;
+  height: calc(100vh - 5em);
+  overflow: auto;
   flex: 0 0 15%;
   border-right: 1px solid var(--colors-border);  
   @media (max-width: 1200px){


### PR DESCRIPTION
Two changes here: 
 1. The navigation was set at a sticky position far down in the window, so if you had the developer tools open in the browser while looking at the page, you couldn't access the bottom of the navigation section. I fixed this by making the navigation sticky to the top of the window, and only as tall as the viewport (scrolling otherwise). 

Old 
![sidebar cut off](https://user-images.githubusercontent.com/4480480/68313648-8aa06900-007a-11ea-86ee-3160fc0c523f.png)

New 
<img width="1680" alt="sidebar scrolls" src="https://user-images.githubusercontent.com/4480480/68313912-fb478580-007a-11ea-9f42-fc2bbc86fc25.png">

 2. Add links in the Popover and Overlay section to point to the 'Blocks for Popover and Overlay Components' documentation. 
