### PR TITLE
Add a consistent focus state to buttons and rowItems

### DIFF
--- a/lib/button-group.js
+++ b/lib/button-group.js
@@ -16,13 +16,13 @@ export const ButtonSegment = styled(Button)`
   flex: 0 0 auto;
   border-radius: 0;
   border-right-style: none;
+
   &[aria-checked='true'],
   &:active {
     color: var(--colors-selected-text);
     background-color: var(--colors-selected-background);
     z-index: 1;
   }
-
   &:first-child {
     border-radius: var(--rounded) 0 0 var(--rounded);
   }

--- a/lib/button-group.js
+++ b/lib/button-group.js
@@ -23,9 +23,11 @@ export const ButtonSegment = styled(Button)`
     background-color: var(--colors-selected-background);
     z-index: 1;
   }
+
   &:first-child {
     border-radius: var(--rounded) 0 0 var(--rounded);
   }
+
   &:last-child {
     border-radius: 0 var(--rounded) var(--rounded) 0;
     border-right-style: solid;

--- a/lib/button.js
+++ b/lib/button.js
@@ -55,15 +55,18 @@ const StyledButton = styled.span`
   ${({ size }) => sizes[size]}
 `;
 
-const hover = (...args) => css`
+const focus = (...args) => css`
   &:focus,
   button:focus &,
   a:focus & {
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
     outline: none;
     color: var(--colors-selected-text);
-    background-color: var(--colors-selected-background);
+    ${css(...args)}
   }
+`;
+
+const hover = (...args) => css`
   &:hover,
   button:hover &,
   a:hover & {
@@ -86,6 +89,9 @@ const variants = {
     ${hover`
       background-color: var(--colors-secondaryBackground);
     `}
+    ${focus`
+      background-color: var(--colors-selected-background);
+    `}
   `,
   secondary: css`
     color: var(--colors-secondary);
@@ -93,6 +99,9 @@ const variants = {
     border: 1px solid var(--colors-secondary);
     ${hover`
       background-color: var(--colors-secondaryBackground);
+    `}
+    ${focus`
+      background-color: var(--colors-selected-background);
     `}
   `,
   cta: css`
@@ -102,7 +111,6 @@ const variants = {
     box-shadow: 4px 4px 0 var(--colors-primary);
     margin-right: 4px;
     ${hover`
-      background-color: var(--colors-secondaryBackground);
       box-shadow: 2px 2px 0 var(--colors-primary);
     `}
   `,
@@ -111,7 +119,10 @@ const variants = {
     background-color: var(--colors-background);
     border: 1px solid var(--colors-secondary);
     ${hover`
-      color: vaqr(--colors-warning-text);
+      color: var(--colors-warning-text);
+      background-color: var(--colors-warning-background);
+    `}
+   ${focus`
       background-color: var(--colors-warning-background);
     `}
   `,

--- a/lib/button.js
+++ b/lib/button.js
@@ -86,22 +86,24 @@ const variants = {
     color: var(--colors-primary);
     background-color: var(--colors-background);
     border: 2px solid var(--colors-primary);
-    ${hover`
-      background-color: var(--colors-secondaryBackground);
-    `}
+
     ${focus`
       background-color: var(--colors-selected-background);
+    `}
+    ${hover`
+      background-color: var(--colors-secondaryBackground);
     `}
   `,
   secondary: css`
     color: var(--colors-secondary);
     background-color: var(--colors-background);
     border: 1px solid var(--colors-secondary);
-    ${hover`
-      background-color: var(--colors-secondaryBackground);
-    `}
+
     ${focus`
       background-color: var(--colors-selected-background);
+    `}
+    ${hover`
+      background-color: var(--colors-secondaryBackground);
     `}
   `,
   cta: css`
@@ -110,6 +112,7 @@ const variants = {
     border: 2px solid var(--colors-primary);
     box-shadow: 4px 4px 0 var(--colors-primary);
     margin-right: 4px;
+
     ${hover`
       box-shadow: 2px 2px 0 var(--colors-primary);
     `}
@@ -118,11 +121,12 @@ const variants = {
     color: var(--colors-secondary);
     background-color: var(--colors-background);
     border: 1px solid var(--colors-secondary);
-    ${hover`
-      color: var(--colors-warning-text);
+
+    ${focus`
       background-color: var(--colors-warning-background);
     `}
-   ${focus`
+    ${hover`
+      color: var(--colors-warning-text);
       background-color: var(--colors-warning-background);
     `}
   `,

--- a/lib/button.js
+++ b/lib/button.js
@@ -59,7 +59,7 @@ const hover = (...args) => css`
   &:focus,
   button:focus &,
   a:focus & {
-    box-shadow: 0 0 0 1px white, 0 0 0 3px red;
+    box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-selected-focused);
     outline: none;
   }
   &:hover,

--- a/lib/button.js
+++ b/lib/button.js
@@ -60,7 +60,7 @@ const focus = (...args) => css`
   button:focus &,
   a:focus & {
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
-    outline: none;
+    outline-colour: transparent;
     color: var(--colors-selected-text);
     ${css(...args)}
   }

--- a/lib/button.js
+++ b/lib/button.js
@@ -56,6 +56,12 @@ const StyledButton = styled.span`
 `;
 
 const hover = (...args) => css`
+  &:focus,
+  button:focus &,
+  a:focus & {
+    box-shadow: 0 0 0 1px white, 0 0 0 3px red;
+    outline: none;
+  }
   &:hover,
   button:hover &,
   a:hover & {

--- a/lib/button.js
+++ b/lib/button.js
@@ -59,8 +59,10 @@ const hover = (...args) => css`
   &:focus,
   button:focus &,
   a:focus & {
-    box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-selected-focused);
+    box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
     outline: none;
+    color: var(--colors-selected-text);
+    background-color: var(--colors-selected-background);
   }
   &:hover,
   button:hover &,

--- a/lib/button.js
+++ b/lib/button.js
@@ -60,7 +60,7 @@ const focus = (...args) => css`
   button:focus &,
   a:focus & {
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
-    outline-colour: transparent;
+    outline-color: transparent;
     color: var(--colors-selected-text);
     ${css(...args)}
   }

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -115,14 +115,34 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   position: relative;
   padding: var(--space-1);
   text-decoration: none;
-  &:focus {
+  margin: var(--space-1) 0;
+
+  &:focus,
+  button:focus &,
+  a:focus & {
+    box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
+    outline: none;
     color: var(--colors-selected-text);
     background-color: var(--colors-selected-background);
+
     ${ResultDescription} {
       color: var(--colors-selected-secondary);
     }
   }
-  ${ResultItemWrap} + ${ResultItemWrap} & {
+  &:hover,
+  button:hover &,
+  a:hover & {
+    background-color: var(--colors-secondaryBackground);
+    text-decoration: none;
+  }
+  &:active,
+  button:active &,
+  a:active & {
+    color: var(--colors-selected-text);
+    background-color: var(--colors-selected-background);
+  }
+
+  ${ResultItemWrap} + ${ResultItemWrap} {
     border-top: 1px solid var(--colors-border);
   }
 `;

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -121,7 +121,7 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   button:focus &,
   a:focus & {
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
-    outline-colour: transparent;
+    outline-color: transparent;
     color: var(--colors-selected-text);
     background-color: var(--colors-selected-background);
 

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -121,7 +121,7 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   button:focus &,
   a:focus & {
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
-    outline: none;
+    outline-colour: transparent;
     color: var(--colors-selected-text);
     background-color: var(--colors-selected-background);
 


### PR DESCRIPTION
Adds a stylized focus ring around buttons and row items, and makes the hover, focus, and active styles consistent between those elements.

Examples:

![Screencast3](https://user-images.githubusercontent.com/654275/68779813-445f8280-0603-11ea-9664-ffeead9e2e2f.gif)
![Screencast2](https://user-images.githubusercontent.com/654275/68779814-445f8280-0603-11ea-869d-f46a1a58baaf.gif)
![Screencast](https://user-images.githubusercontent.com/654275/68779815-445f8280-0603-11ea-86e6-582a44e95ee3.gif)
