### PR TITLE
Peppered deltadromeus: ResultItem fixes

### DIFF
--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -154,8 +154,8 @@ ResultItem.defaultProps = {
 
 const resultOptions = [
   { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },
-  { id: 2, domain: 'fan-coal', description: 'The Glitch community site', private: true },
-  { id: 3, domain: 'shared-components', description: 'how meta', private: false },
+  { id: 2, domain: 'fan-coal', description: 'this one is yellow because we are pretending it is a private project', private: true },
+  { id: 3, domain: 'peppered-deltadromeus', description: 'this is a remix of shared components', private: false },
 ];
 
 const Container = styled.div`

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -188,7 +188,11 @@ export const StoryResultsList = () => {
         {code`
           <ResultsList value={value} onChange={onChange} options={resultOptions}>
             {({ item, buttonProps }) => (
-              <ResultItem onClick={() => addProjectToCollection(item.id)} isPrivate={item.private} {...buttonProps}>
+              <ResultItem 
+                onClick={() => addProjectToCollection(item.id)} 
+                isPrivate={item.private}
+                {...buttonProps}
+              >
                 <ResultInfo>
                   <ResultName isPrivate={item.private}>{item.name}</ResultName>
                   <ResultDescription>{item.description}</ResultDescription>

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -95,9 +95,21 @@ export const ResultInfo = styled.span.attrs(() => ({ 'data-module': 'ResultInfo'
   width: 100%;
 `;
 
-export const ResultName = styled.span.attrs(() => ({ 'data-module': 'ResultName' }))`
+export const ResultNameBase = styled.span.attrs(() => ({ 'data-module': 'ResultName' }))`
   font-size: var(--fontSizes-small);
 `;
+
+const NameIcon = styled(Icon)`
+  margin-right: 5px;
+  vertical-align: baseline;
+`;
+
+export const ResultName = ({ isPrivate, children, ...props }) => (
+  <ResultNameBase {...props}>
+    {isPrivate && <NameIcon icon="private" alt="private" />}
+    {children}
+  </ResultNameBase>
+);
 
 export const ResultDescription = styled.span.attrs(() => ({ 'data-module': 'ResultDescription' }))`
   display: block;
@@ -113,12 +125,12 @@ export const ResultDescription = styled.span.attrs(() => ({ 'data-module': 'Resu
 // and could also work as an <a>.
 // Its defined as a span here so that it doesn't inherit the PropTypes of UnstyledButton
 // when its being used as an <a>.
-export const PublicResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem' }))`
+export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem' }))`
   display: flex;
   width: 100%;
   font-size: var(--fontSizes-normal);
   color: var(--colors-primary);
-  background-color: var(--colors-background);
+  background-color: ${props => props.isPrivate ? "var(--colors-private-background);" : "var(--colors-background);"};
   position: relative;
   padding: var(--space-1);
   text-decoration: none;
@@ -150,30 +162,9 @@ export const PublicResultItem = styled.span.attrs(() => ({ 'data-module': 'Resul
   }
 `;
 
-PublicResultItem.defaultProps = {
+ResultItem.defaultProps = {
   as: UnstyledButton,
 };
-
-const PrivateResultItemWrap = styled(PublicResultItem)`
-  background-color: var(--colors-private-background);
-`;
-
-export const PrivateResultItem = ({ children, forwardedRef, ...props }) => (
-  <PrivateResultItemWrap ref={forwardedRef} {...props}>
-    <Icon icon="private" />
-    {children}
-  </PrivateResultItemWrap>
-);
-
-export const ResultItem = React.forwardRef(({ isPrivate, ...props }, ref) => {
-  if (isPrivate) {
-    return (
-      <PrivateResultItem {...props} forwardedRef={ref} />
-    )
-  }
-
-  return <PublicResultItem {...props} ref={ref} />
-});
 
 const resultOptions = [
   { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },
@@ -197,9 +188,9 @@ export const StoryResultsList = () => {
         {code`
           <ResultsList value={value} onChange={onChange} options={resultOptions}>
             {({ item, buttonProps }) => (
-              <ResultItem onClick={() => addProjectToCollection(item.id)} {...buttonProps}>
+              <ResultItem onClick={() => addProjectToCollection(item.id)} isPrivate={item.private} {...buttonProps}>
                 <ResultInfo>
-                  <ResultName>{item.name}</ResultName>
+                  <ResultName isPrivate={item.private}>{item.name}</ResultName>
                   <ResultDescription>{item.description}</ResultDescription>
                 </ResultInfo>
               </ResultItem>
@@ -237,7 +228,7 @@ export const StoryResultsList = () => {
           {({ item, buttonProps }) => (
             <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} isPrivate={item.private} {...buttonProps}>
               <ResultInfo>
-                <ResultName>{item.domain}</ResultName>
+                <ResultName isPrivate={item.private}>{item.domain}</ResultName>
                 {item.description && <ResultDescription>{item.description}</ResultDescription>}
               </ResultInfo>
             </ResultItem>

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { onArrowKeys } from './keyboard-navigation';
 import { UnstyledButton } from './button';
+import { Icon } from './icon';
+
 import { code, CodeExample, PropsDefinition, Prop } from './story-utils';
 
 const ScrollContainer = styled.div`
@@ -111,12 +113,12 @@ export const ResultDescription = styled.span.attrs(() => ({ 'data-module': 'Resu
 // and could also work as an <a>.
 // Its defined as a span here so that it doesn't inherit the PropTypes of UnstyledButton
 // when its being used as an <a>.
-export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem' }))`
+export const PublicResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem' }))`
   display: flex;
   width: 100%;
   font-size: var(--fontSizes-normal);
   color: var(--colors-primary);
-  background-color: ${props => props.private ? "var(--colors-private-background);" : "var(--colors-background);"};
+  background-color: var(--colors-background);
   position: relative;
   padding: var(--space-1);
   text-decoration: none;
@@ -148,8 +150,29 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   }
 `;
 
-ResultItem.defaultProps = {
+PublicResultItem.defaultProps = {
   as: UnstyledButton,
+};
+
+const PrivateResultItemWrap = styled(PublicResultItem)`
+  background-color: var(--colors-private-background);
+`;
+
+export const PrivateResultItem = ({ children, ...props }) => (
+  <PrivateResultItemWrap {...props}>
+    <Icon icon="private" />
+    {children}
+  </PrivateResultItemWrap>
+);
+
+export const ResultItem = ({ isPrivate, ...props }) => {
+  if (isPrivate) {
+    return (
+      <PrivateResultItem {...props} />
+    )
+  }
+
+  return <PublicResultItem {...props} />
 };
 
 const resultOptions = [
@@ -212,7 +235,7 @@ export const StoryResultsList = () => {
       <Container>
         <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions}>
           {({ item, buttonProps }) => (
-            <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} private={item.private} {...buttonProps}>
+            <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} isPrivate={item.private} {...buttonProps}>
               <ResultInfo>
                 <ResultName>{item.domain}</ResultName>
                 {item.description && <ResultDescription>{item.description}</ResultDescription>}

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -21,7 +21,12 @@ const ResultsListContainer = styled.ul`
   list-style-type: none;
 `;
 
-const ResultItemWrap = styled.li``;
+const ResultItemWrap = styled.li`
+  border-bottom: 1px solid var(--colors-border);
+  &:last-of-type {
+    border-bottom: none;
+  }
+`;
 
 export const ResultsList = React.forwardRef(({ scroll, value, options, onChange, onKeyDown, children, ...props }, ref) => {
   const refs = React.useRef([]);
@@ -111,7 +116,7 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   width: 100%;
   font-size: var(--fontSizes-normal);
   color: var(--colors-primary);
-  background-color: var(--colors-background);
+  background-color: ${props => props.private ? "var(--colors-private-background);" : "var(--colors-background);"};
   position: relative;
   padding: var(--space-1);
   text-decoration: none;
@@ -141,10 +146,6 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
     color: var(--colors-selected-text);
     background-color: var(--colors-selected-background);
   }
-
-  ${ResultItemWrap} + ${ResultItemWrap} {
-    border-top: 1px solid var(--colors-border);
-  }
 `;
 
 ResultItem.defaultProps = {
@@ -152,8 +153,9 @@ ResultItem.defaultProps = {
 };
 
 const resultOptions = [
-  { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library' },
-  { id: 2, domain: 'fan-coal', description: 'The Glitch community site' },
+  { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },
+  { id: 2, domain: 'fan-coal', description: 'The Glitch community site', private: true },
+  { id: 3, domain: 'shared-components', description: 'how meta', private: false },
 ];
 
 const Container = styled.div`
@@ -210,7 +212,7 @@ export const StoryResultsList = () => {
       <Container>
         <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions}>
           {({ item, buttonProps }) => (
-            <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} {...buttonProps}>
+            <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} private={item.private} {...buttonProps}>
               <ResultInfo>
                 <ResultName>{item.domain}</ResultName>
                 {item.description && <ResultDescription>{item.description}</ResultDescription>}

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -158,22 +158,22 @@ const PrivateResultItemWrap = styled(PublicResultItem)`
   background-color: var(--colors-private-background);
 `;
 
-export const PrivateResultItem = ({ children, ...props }) => (
-  <PrivateResultItemWrap {...props}>
+export const PrivateResultItem = ({ children, forwardedRef, ...props }) => (
+  <PrivateResultItemWrap ref={forwardedRef} {...props}>
     <Icon icon="private" />
     {children}
   </PrivateResultItemWrap>
 );
 
-export const ResultItem = ({ isPrivate, ...props }) => {
+export const ResultItem = React.forwardRef(({ isPrivate, ...props }, ref) => {
   if (isPrivate) {
     return (
-      <PrivateResultItem {...props} />
+      <PrivateResultItem {...props} forwardedRef={ref} />
     )
   }
 
-  return <PublicResultItem {...props} />
-};
+  return <PublicResultItem {...props} ref={ref} />
+});
 
 const resultOptions = [
   { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },

--- a/lib/stories.js
+++ b/lib/stories.js
@@ -134,11 +134,11 @@ const AppContainer = () => {
     <>
     <Wrapper>
       <Nav>
-        {modules.map((module, i) => (
+        {modules.map((module) => (
           Object.entries(module).map(
             ([name], i) => 
               (name.startsWith('Story') && !name.includes('_')) && (
-                <NavLink href={`#${name}`}>
+                <NavLink href={`#${name}`} key={name+i}>
                   {name.replace(/_/g, ' ').replace('Story', '')}
                 </NavLink>
               )


### PR DESCRIPTION
Adds back dividers between result items in a results list and takes an optional private prop that will give it a yellow background.
<img width="337" alt="Screen Shot 2019-12-03 at 4 37 38 PM" src="https://user-images.githubusercontent.com/6620164/70091976-3d68d600-15eb-11ea-80e2-bc372adf90e2.png">

remix: https://peppered-deltadromeus.glitch.me/#StoryResultsList