### PR TITLE
Sparkly dichondra: Set Max-Width on Pop-overs

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -15,7 +15,7 @@ const TitleWrap = styled.header`
 const TitleContent = styled.h2`
   flex: 1 0 auto;
   margin: 0;
-  padding: 0 var(--space-1);
+  padding: 0;
   font-size: var(--fontSizes-small);
 `;
 

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -44,7 +44,7 @@ const usePositionAdjustment = () => {
 const PopoverWrap = styled.div`
   position: absolute;
   width: auto;
-  max-width: 320px;
+  max-width: 350px;
   ${({ align }) => alignments[align]}
 `;
 

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -44,6 +44,7 @@ const usePositionAdjustment = () => {
 const PopoverWrap = styled.div`
   position: absolute;
   width: auto;
+  max-width: 320px;
   ${({ align }) => alignments[align]}
 `;
 
@@ -71,6 +72,7 @@ const PopoverInner = styled.div`
   font-size: var(--fontSizes-small);
   border-radius: var(--rounded);
   text-align: left;
+  max-width: 100%;
 
   border: 1px solid var(--colors-border);
   box-shadow: var(--popShadow);
@@ -179,6 +181,7 @@ Popover.propTypes = {
 
 const WidePopover = styled.div`
   width: 22rem;
+  max-width: 100%;
 `;
 
 export const StoryPopover = () => (

--- a/watch.json
+++ b/watch.json
@@ -3,7 +3,6 @@
     "include": ["^package\\.json$", "^\\.env$"]
   },
   "restart": {
-    "exclude": ["^lib/"],
     "include": ["\\.js$", "\\.json"]
   },
   "throttle": 1000


### PR DESCRIPTION
Should prevent very wide pop-overs such as 
![image](https://user-images.githubusercontent.com/519336/70253240-d2391400-1750-11ea-99f3-4a4891610b65.png)

Also removed extraneous padding on popover titles.
