### PR TITLE
Ritzy-dichondra: fix extraneous "true" in CSS for Button

### DIFF
--- a/lib/button.js
+++ b/lib/button.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import omit from 'lodash/omit';
 import { Icon } from './icon';
 import { sizes } from './system';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
@@ -34,7 +33,7 @@ const withFilter = (Tag, filter = []) => {
 	return props => <Tag {...omit(props, filter)} />;
 };
 const Tag = "button";
-const StyledButton = styled(withFilter(Tag, ['textWrap'])`
+const StyledButton = styled(withFilter(Tag, ['textWrap']))`
   display: inline-block;
   border-radius: var(--rounded);
   font-family: var(--fonts-sans);

--- a/lib/button.js
+++ b/lib/button.js
@@ -29,11 +29,7 @@ BaseButton.defaultProps = {
   type: 'button',
 };
 
-const withFilter = (Tag, filter = []) => {
-	return props => <Tag {...omit(props, filter)} />;
-};
-const Tag = "button";
-const StyledButton = styled(withFilter(Tag, ['textWrap']))`
+const StyledButton = styled.span`
   display: inline-block;
   border-radius: var(--rounded);
   font-family: var(--fonts-sans);

--- a/lib/button.js
+++ b/lib/button.js
@@ -188,7 +188,7 @@ export const StoryButton_variants_and_sizes = () => (
     <p>(Note that the actual variant / size names are in lowercase, but button text should be written in title case.)</p>
     <Container>
       {['Primary', 'Secondary', 'CTA', 'Warning'].map((label) => (
-        <Button key={label} as="span" disabled={false} size="normal" imagePosition="left" textWrap={true} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
+        <Button key={label} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
           {label}
         </Button>
       ))}

--- a/lib/button.js
+++ b/lib/button.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import omit from 'lodash/omit';
 import { Icon } from './icon';
 import { sizes } from './system';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
@@ -29,7 +30,11 @@ BaseButton.defaultProps = {
   type: 'button',
 };
 
-const StyledButton = styled(({variant, size, textWrap, ...props}) => <span {...props} />)`
+const withFilter = (Tag, filter = []) => {
+	return props => <Tag {...omit(props, filter)} />;
+};
+const Tag = "button";
+const StyledButton = styled(withFilter(Tag, ['textWrap'])`
   display: inline-block;
   border-radius: var(--rounded);
   font-family: var(--fonts-sans);

--- a/lib/button.js
+++ b/lib/button.js
@@ -189,7 +189,7 @@ export const StoryButton_variants_and_sizes = () => (
     <p>(Note that the actual variant / size names are in lowercase, but button text should be written in title case.)</p>
     <Container>
       {['Primary', 'Secondary', 'CTA', 'Warning'].map((label) => (
-        <Button key={label} as="span" size="normal" imagePosition="left" textWrap={true} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
+        <Button key={label} as="span" disabled={false} size="normal" imagePosition="left" textWrap={true} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
           {label}
         </Button>
       ))}

--- a/lib/button.js
+++ b/lib/button.js
@@ -189,7 +189,7 @@ export const StoryButton_variants_and_sizes = () => (
     <p>(Note that the actual variant / size names are in lowercase, but button text should be written in title case.)</p>
     <Container>
       {['Primary', 'Secondary', 'CTA', 'Warning'].map((label) => (
-        <Button key={label} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
+        <Button key={label} as="span" size="normal" imagePosition="left" textWrap={true} variant={label.toLowerCase()} onClick={() => console.log(`clicked ${label}`)}>
           {label}
         </Button>
       ))}

--- a/lib/button.js
+++ b/lib/button.js
@@ -29,7 +29,7 @@ BaseButton.defaultProps = {
   type: 'button',
 };
 
-const StyledButton = styled.span`
+const StyledButton = styled(({variant, size, textWrap, ...props}) => <span {...props} />)`
   display: inline-block;
   border-radius: var(--rounded);
   font-family: var(--fonts-sans);
@@ -52,7 +52,6 @@ const StyledButton = styled.span`
   text-decoration: none;
 
   ${({ variant }) => variants[variant]}
-  ${({ textWrap }) => textWrap}
   ${({ size }) => sizes[size]}
   ${({ textWrap }) =>
       textWrap &&

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "prop-types": "15.x",
-    "react-textarea-autosize": "^7.1.0"
+    "react-textarea-autosize": "^7.1.0",
+    "lodash.omit": "^4.5.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "prop-types": "15.x",
-    "react-textarea-autosize": "^7.1.0",
-    "lodash.omit": "^4.5.0"
+    "react-textarea-autosize": "^7.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,5 +1,6 @@
 dependencies:
   dotenv: 8.2.0
+  lodash.omit: 4.5.0
   prop-types: 15.7.2
   react-textarea-autosize: 7.1.0
 devDependencies:
@@ -1343,6 +1344,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  /lodash.omit/4.5.0:
+    dev: false
+    resolution:
+      integrity: sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
   /lodash/4.17.15:
     dev: true
     resolution:
@@ -2202,6 +2207,7 @@ specifiers:
   eslint-plugin-react: ^7.14.2
   eslint-plugin-react-hooks: ^1.5.0
   express: 4.16.4
+  lodash.omit: ^4.5.0
   prettier: ^1.18.2
   prop-types: 15.x
   react: ^16.8.0

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,6 +1,5 @@
 dependencies:
   dotenv: 8.2.0
-  lodash.omit: 4.5.0
   prop-types: 15.7.2
   react-textarea-autosize: 7.1.0
 devDependencies:
@@ -1344,10 +1343,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
-  /lodash.omit/4.5.0:
-    dev: false
-    resolution:
-      integrity: sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
   /lodash/4.17.15:
     dev: true
     resolution:
@@ -2207,7 +2202,6 @@ specifiers:
   eslint-plugin-react: ^7.14.2
   eslint-plugin-react-hooks: ^1.5.0
   express: 4.16.4
-  lodash.omit: ^4.5.0
   prettier: ^1.18.2
   prop-types: 15.x
   react: ^16.8.0


### PR DESCRIPTION
[Clubhouse ticket](https://app.clubhouse.io/glitch/story/6187/css-in-latest-shared-components-button-is-broken-true-rendering-next-to-font-size-property)

I can't reproduce this bug in the examples at shared-components.glitch.me, but here's what some buttons in the community site look like sometimes: 

![dev tools](https://user-images.githubusercontent.com/4480480/71858387-a2af5b80-30b0-11ea-9529-b80a7c35abc7.png)
![glitch.com](https://user-images.githubusercontent.com/4480480/71858393-ae028700-30b0-11ea-8beb-8574290f37f8.png)

Note the CSS, on the line under `border`. And that the button is smaller than normal (hard to tell in the screenshot)

I tested this by using `createRemoteComponent` in a local branch. 